### PR TITLE
Fix the error of sequelize Cannot assign to read only property 'name'…

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,7 @@ module.exports = generators.Base.extend({
         break;
       case 'sequelize':
         productionInstall.push('mysql');
+        productionInstall.push('mysql2');
         productionInstall.push('sequelize');
         devInstall.push('sequelize-cli');
         break;

--- a/app/templates/sequelize/index.js
+++ b/app/templates/sequelize/index.js
@@ -27,7 +27,7 @@ fs
   })
   .forEach(function (file) {
     var model = sequelize.import(path.join(__dirname, file));
-    var startCaseName = startCase(model.name).split(' ').join('');
+    var startCaseName = startCase(model.name).replace(/\s/g, '');
     db[startCaseName] = model;
   });
 

--- a/app/templates/sequelize/index.js
+++ b/app/templates/sequelize/index.js
@@ -4,7 +4,7 @@ var databaseConfig = require('../../config/database.js');
 var fs = require('fs');
 var path = require('path');
 var app = require('../../index');
-
+var startCase = require('lodash').startCase;
 
 if (!databaseConfig[app.settings.env]) {
   throw new Error('Database configuration object for missing for environment ' + app.settings.env);
@@ -27,10 +27,8 @@ fs
   })
   .forEach(function (file) {
     var model = sequelize.import(path.join(__dirname, file));
-    model.name = model.name.charAt(0).toUpperCase() + model.name.slice(1).replace(/_(.)/g, function(match, char) {
-        return char.toUpperCase();
-      });
-    db[model.name] = model;
+    var startCaseName = startCase(model.name).split(' ').join('');
+    db[startCaseName] = model;
   });
 
 Object.keys(db).forEach(function (modelName) {


### PR DESCRIPTION
Fix of Error

```
        model.name = model.name.charAt(0).toUpperCase() + model.name.slice(1).replace(/_(.)/g, function(match, char) {
                   ^

TypeError: Cannot assign to read only property 'name' of function 'class extends Model {}'
    at /home/taimurali/my-personal/maskers-test/app/models/index.js:30:20
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/taimurali/my-personal/maskers-test/app/models/index.js:28:6)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Module.require (module.js:585:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/taimurali/my-personal/maskers-test/index.js:27:14)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Module.require (module.js:585:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/taimurali/my-personal/maskers-test/server.js:3:11)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
```